### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to wassima will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.1 (2025-08-11)
+
+### Changed
+- CCADB embedded bundle is updated to latest version. Include a new CA. (#23)
+
 ## 2.0.0 (2025-06-22)
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -19,10 +19,8 @@ This project allows you to access your original operating system trust store, th
 helping you to verify the remote peer certificates. It automatically fallback to an
 embedded trust store generated from the CCADB trusted source.
 
-It works as-is out-of-the-box for MacOS (10.15+), Windows (7+), and Linux. Available on PyPy and Python 3.7+
-
-If your particular operating system is not supported, we can make this happen! Open
-an issue on the repository.
+It works as-is out-of-the-box for any operating systems out there.
+Available on PyPy and Python 3.7+
 
 ## ✨ Installation
 

--- a/src/wassima/_version.py
+++ b/src/wassima/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## 2.0.1 (2025-08-11)

### Changed
- CCADB embedded bundle is updated to latest version. Include a new CA. (#23)
