### PR TITLE
:bookmark: Release 2.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to wassima will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.0.5 (2026-02-07)
+
+### Fixed
+- Unreasonable deep scan under FreeBSD causing a significant lag while loading trusted CAs. (https://github.com/jawah/niquests/issues/332)
+
+### Changed
+- CCADB embedded bundle is updated to latest version. (#41)
+
 ## 2.0.4 (2026-01-13)
 
 ### Fixed

--- a/src/wassima/_os/_linux.py
+++ b/src/wassima/_os/_linux.py
@@ -11,7 +11,7 @@ BUNDLE_TRUST_STORE_DIRECTORIES: list[str] = [
     "/usr/local/ssl",
     "/usr/local/openssl",
     "/usr/local/etc/openssl",
-    "/usr/local/share",
+    "/usr/local/share/certs",
     "/usr/lib/ssl",
     "/usr/ssl",
     "/etc/openssl",
@@ -36,6 +36,7 @@ BANNED_KEYWORD_NOT_TLS: set[str] = {
     "timestamp",
     "codesign",
     "ocsp",
+    "untrusted",
 }
 
 
@@ -74,7 +75,7 @@ def root_der_certificates() -> list[bytes]:
                         start_marker = chunk.find("-----BEGIN CERTIFICATE-----" + line_ending)
 
                         if start_marker == -1:
-                            break
+                            break  # Defensive: file that aren't PEM encoded in target directories(...)
 
                         pem_reconstructed = "".join([chunk[start_marker:], boundary])
 

--- a/src/wassima/_version.py
+++ b/src/wassima/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## 2.0.5 (2026-02-07)

### Fixed
- Unreasonable deep scan under FreeBSD causing a significant lag while loading trusted CAs. (https://github.com/jawah/niquests/issues/332)

### Changed
- CCADB embedded bundle is updated to latest version. (#41)
