### PR TITLE
Release 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to wassima will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.0 (2026-05-10)
+
+### Added
+- `set_cache_ttl` top level function to set, in seconds, how long the CA bundle will be valid for until re-pooling from the OS.
+- Parameter `hybrid_store` boolean to force concatenate your OS CA bundle with the embedded CCADB bundle. E.g. `wassima.generate_ca_bundle(hybrid_store=True)`.
+
+### Fixed
+- Very old Linux with a stale CA bundle will now automatically be extended with the CCADB embedded bundle. (3 years-not updated required)
+- The cache being too aggressive, never invalidating itself, thus need a proper restart or manual lru_cache invalidation.
+  Now the CA bundle output will expire after 12 hours to let updates propagate correctly from the OS.
+- Ensured no duplicate CA appears in the final list.
+
+### Changed
+- CCADB embedded bundle is updated to latest version.
+
 ## 2.0.6 (2026-04-07)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2.1.0 (2026-05-10)
 
 ### Added
-- `set_cache_ttl` top level function to set, in seconds, how long the CA bundle will be valid for until re-pooling from the OS.
+- `set_cache_ttl` top level function to set, in seconds, how long the CA bundle will be valid for until re-polling from the OS.
 - Parameter `hybrid_store` boolean to force concatenate your OS CA bundle with the embedded CCADB bundle. E.g. `wassima.generate_ca_bundle(hybrid_store=True)`.
 
 ### Fixed
-- Very old Linux with a stale CA bundle will now automatically be extended with the CCADB embedded bundle. (3 years-not updated required)
+- Very old Linux with a stale CA bundle will now automatically be extended with the CCADB embedded bundle (no updates for at least 3 years).
 - The cache being too aggressive, never invalidating itself, thus need a proper restart or manual lru_cache invalidation.
   Now the CA bundle output will expire after 12 hours to let updates propagate correctly from the OS.
 - Ensured no duplicate CA appears in the final list.

--- a/README.md
+++ b/README.md
@@ -80,3 +80,55 @@ bundle = wassima.generate_ca_bundle()
 # ... It contains a string with all of your root CAs, PLUS your own 'myrootca.pem'.
 # It is not a path but the file content itself.
 ```
+
+*D) Use a hybrid trust store (OS + embedded CCADB bundle)*
+
+```python
+import wassima
+
+# By default, only your OS trust store is used (with the embedded CCADB
+# bundle as a fallback when the OS exposes nothing). Pass `hybrid_store=True`
+# to force concatenating the embedded CCADB bundle in addition to the OS
+# trust store. Useful in containers or appliances that ship with a slim or
+# outdated system trust store.
+ctx = wassima.create_default_ssl_context(hybrid_store=True)
+
+# Available on every public top-level entry point:
+wassima.root_der_certificates(hybrid_store=True)
+wassima.root_pem_certificates(hybrid_store=True)
+wassima.generate_ca_bundle(hybrid_store=True)
+```
+
+On Linux/BSD, when the system trust store has not been updated for at least
+3 years, `hybrid_store=True` is implicitly applied so that the result is
+never silently outdated.
+
+The output of `root_der_certificates()` (and the upper helpers built on top
+of it) is always deduplicated: a given DER certificate is guaranteed to
+appear at most once in the resulting list, regardless of how many OS stores
+or directories it lives in.
+
+### ⏱️ Cache invalidation
+
+For performance reasons the result of `root_der_certificates()` /
+`root_pem_certificates()` is cached. By default, the cache automatically
+expires every 12 hours so that any change to the OS trust store (e.g. a CA
+rotated overnight by your IT department) is picked up without having to
+restart the process.
+
+You can override the TTL at runtime, pass `0` to disable caching entirely:
+
+```python
+import wassima
+
+# Force a refresh every hour:
+wassima.set_cache_ttl(3600)
+
+# Disable caching (every call recomputes):
+wassima.set_cache_ttl(0)
+
+# Restore the default (12 hours):
+wassima.set_cache_ttl(wassima.DEFAULT_CACHE_TTL_SECONDS)
+```
+
+Setting a new TTL invalidates any pending cached result immediately.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ bundle = wassima.generate_ca_bundle()
 # It is not a path but the file content itself.
 ```
 
-*C) Register your own CA in addition to the system's*
+*E) Register your own CA in addition to the system's*
 
 ```python
 import wassima
@@ -81,7 +81,7 @@ bundle = wassima.generate_ca_bundle()
 # It is not a path but the file content itself.
 ```
 
-*D) Use a hybrid trust store (OS + embedded CCADB bundle)*
+*F) Use a hybrid trust store (OS + embedded CCADB bundle)*
 
 ```python
 import wassima

--- a/src/wassima/__init__.py
+++ b/src/wassima/__init__.py
@@ -114,38 +114,39 @@ def root_der_certificates(hybrid_store: bool = False) -> list[bytes]:
     function only re-deduplicates when extra sources (CCADB fallback, hybrid
     bundle, user-registered CAs) are merged on top.
     """
-    with _USER_APPEND_CA_LOCK:
-        certificates = _root_der_certificates()
+    certificates = _root_der_certificates()
 
-        force_hybrid = hybrid_store
+    force_hybrid = hybrid_store
 
-        if IS_LINUX or IS_BSD:
-            from ._os._linux import is_trust_store_stale
+    if IS_LINUX or IS_BSD:
+        from ._os._linux import is_trust_store_stale
 
-            if is_trust_store_stale():
-                force_hybrid = True
+        if is_trust_store_stale():
+            force_hybrid = True
 
-        # Track what's already in the resulting list so that any extension
-        # below (CCADB fallback, hybrid bundle, manually-registered CAs) can
-        # avoid re-adding a DER that is already present.
-        if not certificates:
-            certificates = fallback_der_certificates()
-        elif force_hybrid:
-            seen = set(certificates)
-            certificates = list(certificates)
-            for cert in fallback_der_certificates():
-                if cert not in seen:
-                    seen.add(cert)
-                    certificates.append(cert)
+    # Track what's already in the resulting list so that any extension
+    # below (CCADB fallback, hybrid bundle, manually-registered CAs) can
+    # avoid re-adding a DER that is already present.
+    if not certificates:
+        certificates = fallback_der_certificates()
+    elif force_hybrid:
+        seen = set(certificates)
+        certificates = list(certificates)
+        for cert in fallback_der_certificates():
+            if cert not in seen:
+                seen.add(cert)
+                certificates.append(cert)
 
-        if _MANUALLY_REGISTERED_CA:
-            seen = set(certificates)
-            for cert in _MANUALLY_REGISTERED_CA:
-                if cert not in seen:
-                    seen.add(cert)
-                    certificates.append(cert)
+    manually_registered = tuple(_MANUALLY_REGISTERED_CA)  # snapshot
 
-        return certificates
+    if manually_registered:
+        seen = set(certificates)
+        for cert in manually_registered:
+            if cert not in seen:
+                seen.add(cert)
+                certificates.append(cert)
+
+    return certificates
 
 
 @_ttl_lru_cache

--- a/src/wassima/__init__.py
+++ b/src/wassima/__init__.py
@@ -6,14 +6,33 @@ It aims to provide a pythonic way to retrieve root CAs from your system without 
 from __future__ import annotations
 
 import ssl
-from functools import lru_cache
+import time
+from functools import wraps
 from threading import RLock
+from typing import TYPE_CHECKING, Any
 
+from ._os import (
+    IS_BSD,
+    IS_LINUX,
+)
 from ._os import (
     root_der_certificates as _root_der_certificates,
 )
 from ._os._embed import root_der_certificates as fallback_der_certificates
 from ._version import VERSION, __version__
+
+if TYPE_CHECKING:
+    from typing import Callable, Protocol, TypeVar
+
+    from typing_extensions import ParamSpec
+
+    _P = ParamSpec("_P")
+    _R = TypeVar("_R", covariant=True)
+
+    class _CachedFunc(Protocol[_P, _R]):
+        def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _R: ...
+        def cache_clear(self) -> None: ...
+
 
 # Mozilla TLS recommendations for ciphers
 # General-purpose servers with a variety of clients, recommended for almost all systems.
@@ -23,40 +42,136 @@ _MANUALLY_REGISTERED_CA: list[bytes] = []
 #: Lock for shared register-ca
 _USER_APPEND_CA_LOCK = RLock()
 
+#: Default cache TTL (seconds). Twelve hours. The cache is automatically
+#: invalidated after this duration so that, e.g., a fresh CA being added to
+#: the OS trust store does not require restarting the running process.
+#: Twelve hours (rather than twenty-four) so that, in environments where CAs
+#: are rotated daily, the cache is guaranteed to refresh at least once
+#: between two rotations.
+DEFAULT_CACHE_TTL_SECONDS: int = 43200
 
-@lru_cache()
-def root_der_certificates() -> list[bytes]:
+_CACHE_TTL_SECONDS: int = DEFAULT_CACHE_TTL_SECONDS
+
+
+def _ttl_lru_cache(func: Callable[_P, _R]) -> _CachedFunc[_P, _R]:
+    """A minimal, thread-safe memorizing decorator with a per-call-site TTL."""
+    sentinel = object()
+    cache: dict[Any, Any] = {}
+    state: dict[str, float] = {"expires_at": 0.0}
+    lock = RLock()
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        key = (args, tuple(sorted(kwargs.items()))) if kwargs else args
+        with lock:
+            now = time.monotonic()
+            if now >= state["expires_at"]:
+                cache.clear()
+                state["expires_at"] = now + _CACHE_TTL_SECONDS
+            result = cache.get(key, sentinel)
+            if result is sentinel:
+                result = func(*args, **kwargs)
+                cache[key] = result
+            return result
+
+    def cache_clear() -> None:
+        with lock:
+            cache.clear()
+            state["expires_at"] = 0.0
+
+    wrapper.cache_clear = cache_clear  # type: ignore[attr-defined]
+    return wrapper  # type: ignore[return-value]
+
+
+def set_cache_ttl(seconds: int) -> None:
+    """Override the default cache TTL (in seconds) used by
+    :func:`root_der_certificates` and :func:`root_pem_certificates`.
+
+    A value of ``0`` disables caching entirely (each call recomputes).
+    Any pending cached result is dropped immediately.
+    """
+    global _CACHE_TTL_SECONDS
+    if not isinstance(seconds, int) or isinstance(seconds, bool):
+        raise TypeError("cache TTL must be an int (seconds)")
+    if seconds < 0:
+        raise ValueError("cache TTL cannot be negative")
+    _CACHE_TTL_SECONDS = seconds
+    root_der_certificates.cache_clear()
+    root_pem_certificates.cache_clear()
+
+
+@_ttl_lru_cache
+def root_der_certificates(hybrid_store: bool = False) -> list[bytes]:
+    """Retrieve a list of root certificates from your operating system trust store,
+    DER (binary) encoded.
+
+    When ``hybrid_store`` is ``True``, the embedded CCADB Mozilla bundle is
+    forcibly merged in addition to the OS trusted CAs. This is also implicitly
+    enabled on Linux/BSD when the system trust store appears to be stale
+    (older than 3 years without update).
+
+    The OS-specific backends already guarantee a duplicate-free list; this
+    function only re-deduplicates when extra sources (CCADB fallback, hybrid
+    bundle, user-registered CAs) are merged on top.
+    """
     with _USER_APPEND_CA_LOCK:
         certificates = _root_der_certificates()
 
+        force_hybrid = hybrid_store
+
+        if IS_LINUX or IS_BSD:
+            from ._os._linux import is_trust_store_stale
+
+            if is_trust_store_stale():
+                force_hybrid = True
+
+        # Track what's already in the resulting list so that any extension
+        # below (CCADB fallback, hybrid bundle, manually-registered CAs) can
+        # avoid re-adding a DER that is already present.
         if not certificates:
             certificates = fallback_der_certificates()
+        elif force_hybrid:
+            seen = set(certificates)
+            certificates = list(certificates)
+            for cert in fallback_der_certificates():
+                if cert not in seen:
+                    seen.add(cert)
+                    certificates.append(cert)
 
-        certificates.extend(_MANUALLY_REGISTERED_CA)
+        if _MANUALLY_REGISTERED_CA:
+            seen = set(certificates)
+            for cert in _MANUALLY_REGISTERED_CA:
+                if cert not in seen:
+                    seen.add(cert)
+                    certificates.append(cert)
 
         return certificates
 
 
-@lru_cache()
-def root_pem_certificates() -> list[str]:
+@_ttl_lru_cache
+def root_pem_certificates(hybrid_store: bool = False) -> list[str]:
     """
     Retrieve a list of root certificate from your operating system trust store.
     They will be PEM encoded.
+
+    See :func:`root_der_certificates` for the meaning of ``hybrid_store``.
     """
     pem_certs = []
 
-    for bin_cert in root_der_certificates():
+    for bin_cert in root_der_certificates(hybrid_store=hybrid_store):
         pem_certs.append(ssl.DER_cert_to_PEM_cert(bin_cert))
 
     return pem_certs
 
 
-def generate_ca_bundle() -> str:
+def generate_ca_bundle(hybrid_store: bool = False) -> str:
     """
     Generate an aggregated CA bundle that originate from your system trust store.
     Simply put, concatenated root PEM certificate.
+
+    See :func:`root_der_certificates` for the meaning of ``hybrid_store``.
     """
-    return "\n\n".join(root_pem_certificates())
+    return "\n\n".join(root_pem_certificates(hybrid_store=hybrid_store))
 
 
 def register_ca(pem_or_der_certificate: bytes | str) -> None:
@@ -74,16 +189,18 @@ def register_ca(pem_or_der_certificate: bytes | str) -> None:
             root_der_certificates.cache_clear()
 
 
-def create_default_ssl_context() -> ssl.SSLContext:
+def create_default_ssl_context(hybrid_store: bool = False) -> ssl.SSLContext:
     """
     Instantiate a native SSLContext (client purposes) that ships with your system root CAs.
     In addition to that, assign it the default OpenSSL ciphers suite and set
     TLS 1.2 as the minimum supported version. Also disable commonName check and enforce
     hostname altName verification. The Mozilla Recommended Cipher Suite is used instead of system default.
+
+    See :func:`root_der_certificates` for the meaning of ``hybrid_store``.
     """
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
 
-    ctx.load_verify_locations(cadata=generate_ca_bundle())
+    ctx.load_verify_locations(cadata=generate_ca_bundle(hybrid_store=hybrid_store))
 
     ctx.minimum_version = ssl.TLSVersion.TLSv1_2
     ctx.set_ciphers(MOZ_INTERMEDIATE_CIPHERS)
@@ -108,6 +225,8 @@ __all__ = (
     "generate_ca_bundle",
     "create_default_ssl_context",
     "register_ca",
+    "set_cache_ttl",
+    "DEFAULT_CACHE_TTL_SECONDS",
     "__version__",
     "VERSION",
 )

--- a/src/wassima/_os/_linux.py
+++ b/src/wassima/_os/_linux.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
 import os
+import time
 from pathlib import Path
 from ssl import PEM_cert_to_DER_cert
+
+# Threshold for considering a system trust store as stale (3 years, in seconds).
+STALE_TRUST_STORE_THRESHOLD_SECONDS: int = 3 * 365 * 24 * 3600
+
+# Most recent modification time observed across the trust store source files.
+# Updated by `root_der_certificates`. ``None`` means "no usable info collected".
+_LAST_NEWEST_MTIME: float | None = None
 
 # source: http://gagravarr.org/writing/openssl-certs/others.shtml
 BUNDLE_TRUST_STORE_DIRECTORIES: list[str] = [
@@ -41,7 +49,15 @@ BANNED_KEYWORD_NOT_TLS: set[str] = {
 
 
 def root_der_certificates() -> list[bytes]:
+    global _LAST_NEWEST_MTIME
+
     certificates: list[bytes] = []
+    newest_mtime: float = 0.0
+    # Track files we've already processed by their (device, inode) pair so that
+    # symlinks pointing into the same canonical file (very common, e.g.
+    # /etc/ssl/certs/*.pem -> /usr/share/ca-certificates/.../*.crt) and other
+    # cross-directory aliases are read and parsed exactly once.
+    seen_inodes: set[tuple[int, int]] = set()
 
     for directory in BUNDLE_TRUST_STORE_DIRECTORIES:
         if not os.path.exists(directory):
@@ -60,6 +76,22 @@ def root_der_certificates() -> list[bytes]:
 
                 if any(kw in str(filepath).lower() for kw in BANNED_KEYWORD_NOT_TLS):
                     continue
+
+                try:
+                    st = filepath.stat()
+                except OSError:  # Defensive: stat may fail on broken symlinks
+                    continue
+
+                inode_key = (st.st_dev, st.st_ino)
+                # Some very old cases, we may find st_ino reported
+                # as 0.
+                if st.st_ino != 0:
+                    if inode_key in seen_inodes:
+                        continue
+                    seen_inodes.add(inode_key)
+
+                if st.st_mtime > newest_mtime:
+                    newest_mtime = st.st_mtime
 
                 with open(filepath, encoding="utf-8") as f:
                     bundle = f.read()
@@ -92,4 +124,19 @@ def root_der_certificates() -> list[bytes]:
                 # UnicodeDecodeError -> DER ASN.1 encoded
                 continue
 
+    _LAST_NEWEST_MTIME = newest_mtime if newest_mtime > 0 else None
+
     return certificates
+
+
+def is_trust_store_stale(threshold_seconds: int = STALE_TRUST_STORE_THRESHOLD_SECONDS) -> bool:
+    """Return True if the system trust store has not been updated for longer than
+    ``threshold_seconds``.
+
+    The decision relies on the most recent modification time observed during
+    the last call to :func:`root_der_certificates`. If no modification time has
+    been collected yet, returns False.
+    """
+    if _LAST_NEWEST_MTIME is None:
+        return False
+    return (time.time() - _LAST_NEWEST_MTIME) >= threshold_seconds

--- a/src/wassima/_os/_windows.py
+++ b/src/wassima/_os/_windows.py
@@ -14,7 +14,8 @@ SERVER_AUTH_OID: str = "1.3.6.1.5.5.7.3.1"
 
 
 def root_der_certificates() -> list[bytes]:
-    certificates = []
+    certificates: list[bytes] = []
+    seen: set[bytes] = set()
 
     for system_store in WINDOWS_STORES:
         try:
@@ -30,6 +31,11 @@ def root_der_certificates() -> list[bytes]:
                 if (
                     encoding_type == "x509_asn"  # X.509 ASN.1 data
                 ):
+                    # Same root may live in several stores (ROOT/MY/CA);
+                    # ensure each DER appears at most once.
+                    if cert_bytes in seen:
+                        continue
+                    seen.add(cert_bytes)
                     certificates.append(cert_bytes)
         except PermissionError:  # Defensive: we can't cover that scenario in CI.
             continue

--- a/src/wassima/_version.py
+++ b/src/wassima/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "2.0.6"
+__version__ = "2.1.0"
 VERSION = __version__.split(".")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -111,6 +111,15 @@ def test_set_cache_ttl_invalid() -> None:
         set_cache_ttl(-1)
 
 
+def test_set_cache_ttl_wrong_type() -> None:
+    with pytest.raises(TypeError):
+        set_cache_ttl(1.5)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        set_cache_ttl(True)
+    with pytest.raises(TypeError):
+        set_cache_ttl("60")  # type: ignore[arg-type]
+
+
 def test_set_cache_ttl_zero_disables_cache(monkeypatch) -> None:  # type: ignore[no-untyped-def]
     calls = {"n": 0}
 
@@ -226,3 +235,33 @@ def test_cache_concurrent_access_collapses_misses(monkeypatch) -> None:  # type:
         t.join()
 
     assert calls["n"] == 1
+
+
+def test_windows_backend_dedups_across_stores(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Same root present in several Windows cert stores (e.g. ROOT and CA)
+    must end up only once in the result list. Runs cross-platform by
+    injecting a fake ``ssl.enum_certificates``."""
+    import ssl as _ssl
+    import sys
+
+    duplicate = b"x509-asn-bytes"
+
+    def fake_enum_certificates(store: str):  # type: ignore[no-untyped-def]
+        # Same cert in every store -> dedup must collapse it.
+        yield (duplicate, "x509_asn", True)
+        # An untrusted entry: must be skipped entirely.
+        yield (b"untrusted", "x509_asn", False)
+        # A non x509_asn entry: must be skipped entirely.
+        yield (b"pkcs7", "pkcs_7_asn", True)
+        # A trust set that lacks the SERVER_AUTH OID: must be skipped.
+        yield (b"client-only", "x509_asn", ["1.3.6.1.5.5.7.3.2"])
+
+    monkeypatch.setattr(_ssl, "enum_certificates", fake_enum_certificates, raising=False)
+    # The module may already have been imported on a real Windows host; drop
+    # any cached version so our patched ssl is picked up.
+    sys.modules.pop("wassima._os._windows", None)
+
+    from wassima._os import _windows as win_mod
+
+    certs = win_mod.root_der_certificates()
+    assert certs == [duplicate]

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+import time
+from typing import Iterator
+
+import pytest
+
+import wassima
+from wassima import (
+    DEFAULT_CACHE_TTL_SECONDS,
+    generate_ca_bundle,
+    register_ca,
+    root_der_certificates,
+    root_pem_certificates,
+    set_cache_ttl,
+)
+from wassima._os._embed import root_der_certificates as fallback_der_certificates
+
+
+@pytest.fixture(autouse=True)
+def _reset_caches() -> Iterator[None]:
+    """Make sure each test starts on a clean slate."""
+    wassima._MANUALLY_REGISTERED_CA.clear()
+    root_der_certificates.cache_clear()
+    root_pem_certificates.cache_clear()
+    # Restore the default TTL after each test in case one mutated it.
+    yield
+    set_cache_ttl(DEFAULT_CACHE_TTL_SECONDS)
+    wassima._MANUALLY_REGISTERED_CA.clear()
+    root_der_certificates.cache_clear()
+    root_pem_certificates.cache_clear()
+
+
+def test_no_duplicate_der() -> None:
+    certs = root_der_certificates()
+    assert len(certs) == len(set(certs))
+
+
+def test_register_ca_does_not_introduce_duplicate(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """A CA already present in the OS bundle must not be appended twice when
+    the user also registers it via ``register_ca``."""
+    sample = fallback_der_certificates()[0]
+
+    # Make the OS layer expose `sample` exactly once (each OS backend is
+    # contracted to return a deduplicated list, so we don't need to fake a
+    # buggy backend here).
+    monkeypatch.setattr("wassima._root_der_certificates", lambda: [sample])
+    root_der_certificates.cache_clear()
+
+    register_ca(sample)
+    certs = root_der_certificates()
+    assert certs.count(sample) == 1
+
+
+def test_hybrid_store_does_not_introduce_duplicate(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """When the OS bundle and the embedded CCADB bundle overlap (which is
+    the common case), ``hybrid_store=True`` must not duplicate the shared
+    roots."""
+    embed = fallback_der_certificates()
+    overlapping = embed[0]
+    monkeypatch.setattr("wassima._root_der_certificates", lambda: [overlapping])
+    root_der_certificates.cache_clear()
+
+    out = root_der_certificates(hybrid_store=True)
+    assert out.count(overlapping) == 1
+    assert len(out) == len(set(out))
+
+
+def test_hybrid_store_merges_ccadb(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    sample = b"\x01\x02\x03not-a-real-cert"
+    monkeypatch.setattr("wassima._root_der_certificates", lambda: [sample])
+
+    # Without hybrid_store: only the OS-provided cert.
+    root_der_certificates.cache_clear()
+    assert root_der_certificates(hybrid_store=False) == [sample]
+
+    # With hybrid_store: includes embedded CCADB roots too.
+    embed = fallback_der_certificates()
+    out = root_der_certificates(hybrid_store=True)
+    assert sample in out
+    for c in embed:
+        assert c in out
+    # Still no duplicates.
+    assert len(out) == len(set(out))
+
+
+def test_hybrid_store_propagates_through_pem_and_bundle(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    sample = b"\x10not-real"
+    monkeypatch.setattr("wassima._root_der_certificates", lambda: [sample])
+    root_der_certificates.cache_clear()
+    root_pem_certificates.cache_clear()
+
+    # generate_ca_bundle() with hybrid -> at least as long as without.
+    bundle_plain = generate_ca_bundle(hybrid_store=False)
+    bundle_hybrid = generate_ca_bundle(hybrid_store=True)
+    assert len(bundle_hybrid) > len(bundle_plain)
+
+    pem_hybrid = root_pem_certificates(hybrid_store=True)
+    assert len(pem_hybrid) >= 1
+
+
+def test_create_default_ssl_context_hybrid() -> None:
+    ctx = wassima.create_default_ssl_context(hybrid_store=True)
+    # At least the embedded CCADB bundle should be loaded.
+    stats = ctx.cert_store_stats()
+    assert stats["x509_ca"] >= 1
+
+
+def test_set_cache_ttl_invalid() -> None:
+    with pytest.raises(ValueError):
+        set_cache_ttl(-1)
+
+
+def test_set_cache_ttl_zero_disables_cache(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls = {"n": 0}
+
+    def fake_os_certs() -> list[bytes]:
+        calls["n"] += 1
+        return [b"\xaa"]
+
+    monkeypatch.setattr("wassima._root_der_certificates", fake_os_certs)
+
+    set_cache_ttl(0)
+    root_der_certificates()
+    root_der_certificates()
+    # TTL of zero -> every call recomputes.
+    assert calls["n"] >= 2
+
+
+def test_cache_expires_after_ttl(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    calls = {"n": 0}
+
+    def fake_os_certs() -> list[bytes]:
+        calls["n"] += 1
+        return [b"\xbb"]
+
+    monkeypatch.setattr("wassima._root_der_certificates", fake_os_certs)
+
+    # Use a virtual clock to deterministically jump past the TTL.
+    fake_now = {"t": 1000.0}
+    monkeypatch.setattr(
+        "wassima.time.monotonic",
+        lambda: fake_now["t"],
+    )
+
+    set_cache_ttl(10)
+    root_der_certificates()
+    initial = calls["n"]
+
+    # Within TTL -> cached.
+    fake_now["t"] += 5
+    root_der_certificates()
+    assert calls["n"] == initial
+
+    # Past TTL -> recomputed.
+    fake_now["t"] += 100
+    root_der_certificates()
+    assert calls["n"] == initial + 1
+
+
+def test_linux_stale_trust_store_implicitly_merges(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    # Force the wassima top-level to take the Linux/BSD branch even on
+    # platforms where it would not naturally.
+    monkeypatch.setattr("wassima.IS_LINUX", True)
+    monkeypatch.setattr("wassima.IS_BSD", False)
+
+    sample = b"\x42single-os-cert"
+    monkeypatch.setattr("wassima._root_der_certificates", lambda: [sample])
+
+    from wassima._os import _linux as linux_mod
+
+    monkeypatch.setattr(linux_mod, "is_trust_store_stale", lambda *a, **kw: True)
+    root_der_certificates.cache_clear()
+
+    certs = root_der_certificates()
+
+    # Stale -> CCADB bundle was merged in even without hybrid_store=True.
+    embed = fallback_der_certificates()
+    for c in embed:
+        assert c in certs
+
+
+def test_is_trust_store_stale_helper(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    from wassima._os import _linux as linux_mod
+
+    # When no mtime has been collected -> never considered stale.
+    monkeypatch.setattr(linux_mod, "_LAST_NEWEST_MTIME", None)
+    assert linux_mod.is_trust_store_stale() is False
+
+    # A mtime older than the threshold -> stale.
+    monkeypatch.setattr(
+        linux_mod,
+        "_LAST_NEWEST_MTIME",
+        time.time() - linux_mod.STALE_TRUST_STORE_THRESHOLD_SECONDS - 1,
+    )
+    assert linux_mod.is_trust_store_stale() is True
+
+    # A recent mtime -> not stale.
+    monkeypatch.setattr(linux_mod, "_LAST_NEWEST_MTIME", time.time())
+    assert linux_mod.is_trust_store_stale() is False
+
+
+def test_cache_concurrent_access_collapses_misses(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Under contention at the TTL boundary, only one thread should recompute
+    for a given key (single-lock design, no thundering herd)."""
+    import threading
+
+    calls = {"n": 0}
+    started = threading.Event()
+
+    def slow_os_certs() -> list[bytes]:
+        calls["n"] += 1
+        # Yield so other threads have a chance to pile up if locking is wrong.
+        started.wait(timeout=0.5)
+        return [b"\xcc"]
+
+    monkeypatch.setattr("wassima._root_der_certificates", slow_os_certs)
+    set_cache_ttl(60)
+    root_der_certificates.cache_clear()
+
+    threads = [threading.Thread(target=root_der_certificates) for _ in range(8)]
+    for t in threads:
+        t.start()
+    started.set()
+    for t in threads:
+        t.join()
+
+    assert calls["n"] == 1
+

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ssl
 import time
 from typing import Iterator
 
@@ -242,7 +243,6 @@ def test_windows_backend_dedups_across_stores(monkeypatch) -> None:  # type: ign
     must end up only once in the result list. Runs cross-platform by
     injecting a fake ``ssl.enum_certificates``."""
     import ssl as _ssl
-    import sys
 
     duplicate = b"x509-asn-bytes"
 
@@ -256,12 +256,69 @@ def test_windows_backend_dedups_across_stores(monkeypatch) -> None:  # type: ign
         # A trust set that lacks the SERVER_AUTH OID: must be skipped.
         yield (b"client-only", "x509_asn", ["1.3.6.1.5.5.7.3.2"])
 
-    monkeypatch.setattr(_ssl, "enum_certificates", fake_enum_certificates, raising=False)
-    # The module may already have been imported on a real Windows host; drop
-    # any cached version so our patched ssl is picked up.
-    sys.modules.pop("wassima._os._windows", None)
+    # On non-Windows hosts ``ssl.enum_certificates`` does not exist; provide a
+    # placeholder so that ``from ssl import enum_certificates`` succeeds when
+    # the ``_windows`` submodule is imported below for the first time.
+    if not hasattr(_ssl, "enum_certificates"):
+        monkeypatch.setattr(_ssl, "enum_certificates", lambda store: iter([]), raising=False)
 
+    # Import the Windows backend. On Windows it is likely already loaded as
+    # part of ``wassima`` startup; on other OSes this triggers a fresh import.
     from wassima._os import _windows as win_mod
+
+    # Patch the ``enum_certificates`` name *inside the loaded module*. This is
+    # what ``root_der_certificates`` actually calls (``from ssl import
+    # enum_certificates`` binds the name into the module's namespace), so it
+    # works whether the module was just imported or was already cached at
+    # process startup (which is the case on Windows).
+    monkeypatch.setattr(win_mod, "enum_certificates", fake_enum_certificates)
 
     certs = win_mod.root_der_certificates()
     assert certs == [duplicate]
+
+
+def test_no_deadlock_between_register_ca_and_root_certs(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """Regression test: ``register_ca`` (acquires _USER_APPEND_CA_LOCK then
+    cache lock via ``cache_clear``) must not deadlock with concurrent
+    ``root_der_certificates()`` calls (which used to also acquire
+    _USER_APPEND_CA_LOCK while holding the cache lock during a miss).
+    """
+    import threading
+
+    sample_pem = ssl.DER_cert_to_PEM_cert(fallback_der_certificates()[0])
+
+    def slow_os_certs() -> list[bytes]:
+        # Make the cache-miss compute slow so register_ca has time to enter
+        # its critical section concurrently.
+        time.sleep(0.05)
+        return [b"\xee"]
+
+    monkeypatch.setattr("wassima._root_der_certificates", slow_os_certs)
+    set_cache_ttl(60)
+    root_der_certificates.cache_clear()
+
+    done = threading.Event()
+
+    def reader() -> None:
+        for _ in range(20):
+            root_der_certificates.cache_clear()
+            root_der_certificates()
+
+    def writer() -> None:
+        for _ in range(20):
+            register_ca(sample_pem)
+            wassima._MANUALLY_REGISTERED_CA.clear()
+
+    threads = [threading.Thread(target=reader) for _ in range(4)]
+    threads += [threading.Thread(target=writer) for _ in range(4)]
+    for t in threads:
+        t.start()
+
+    def watchdog() -> None:
+        for t in threads:
+            t.join(timeout=10)
+        done.set()
+
+    threading.Thread(target=watchdog, daemon=True).start()
+
+    assert done.wait(timeout=15), "deadlock detected between register_ca and root_der_certificates"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -226,4 +226,3 @@ def test_cache_concurrent_access_collapses_misses(monkeypatch) -> None:  # type:
         t.join()
 
     assert calls["n"] == 1
-


### PR DESCRIPTION
## 2.1.0 (2026-05-10)

### Added
- `set_cache_ttl` top level function to set, in seconds, how long the CA bundle will be valid for until re-pooling from the OS.
- Parameter `hybrid_store` boolean to force concatenate your OS CA bundle with the embedded CCADB bundle. E.g. `wassima.generate_ca_bundle(hybrid_store=True)`.

### Fixed
- Very old Linux with a stale CA bundle will now automatically be extended with the CCADB embedded bundle. (3 years-not updated required)
- The cache being too aggressive, never invalidating itself, thus need a proper restart or manual lru_cache invalidation.
  Now the CA bundle output will expire after 12 hours to let updates propagate correctly from the OS.
- Ensured no duplicate CA appears in the final list.

### Changed
- CCADB embedded bundle is updated to latest version.
