### PR TITLE
Release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to wassima will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.1 (2026-06-07)
+
+### Fixed
+- Guarded MacOS truststore access in process forks. Apple document as unsafe accessing some CoreFoundation/Security in forks.
+  Previously could lead to a crash (SIGABRT or SIGSEGV). Now automatically falling back to CCADB bundle if in such condition.
+- Windows only materializes trusted roots on demand, so the enumerated OS store could be incomplete and
+  cause `unable to get local issuer certificate` failures. Now extended with the embedded CCADB roots that the Windows AuthRoot
+  CTL trusts for server authentication, even when not yet downloaded locally. (#52)
+
 ## 2.1.0 (2026-05-10)
 
 ### Added

--- a/src/wassima/_os/_macos.py
+++ b/src/wassima/_os/_macos.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ctypes
+import os
 from ctypes import POINTER, byref, c_int32, c_long, c_void_p
 
 # Load frameworks
@@ -12,6 +13,10 @@ _sec = ctypes.CDLL(
     "/System/Library/Frameworks/Security.framework/Security",
     use_errno=True,
 )
+
+# PID of the process that imported (and thus initialized) the CoreFoundation
+# and Security frameworks above. CoreFoundation/Security are NOT fork-safe.
+_INIT_PID = os.getpid()
 
 # Type aliases (CFIndex is a signed long on macOS, 8 bytes on 64-bit)
 CFTypeRef = c_void_p
@@ -196,6 +201,17 @@ def root_der_certificates() -> list[bytes]:
     Certificates explicitly denied via trust settings are excluded.
     Duplicates across domains and queries are removed.
     """
+    # Fork guard: CoreFoundation/Security cannot be used safely in a process
+    # that forked (without exec()) after the frameworks were initialized.
+    # This protection is heuristic, and it's the best I could do with confidence.
+    # Refs:
+    #   - CPython issue #77906 "Python crashes on macOS after fork with no exec":
+    #     https://github.com/python/cpython/issues/77906
+    #   - Apple fork(2) man page, CAVEATS ("...you must exec."):
+    #     https://keith.github.io/xcode-man-pages/fork.2.html
+    if os.getpid() != _INIT_PID:
+        return []
+
     certificates: list[bytes] = []
     seen: set[bytes] = set()
 

--- a/src/wassima/_os/_macos.py
+++ b/src/wassima/_os/_macos.py
@@ -210,7 +210,7 @@ def root_der_certificates() -> list[bytes]:
     #   - Apple fork(2) man page, CAVEATS ("...you must exec."):
     #     https://keith.github.io/xcode-man-pages/fork.2.html
     if os.getpid() != _INIT_PID:
-        return []
+        return []  # Defensive: forked-child path
 
     certificates: list[bytes] = []
     seen: set[bytes] = set()

--- a/src/wassima/_os/_windows.py
+++ b/src/wassima/_os/_windows.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
+import ctypes
+import hashlib
+import sys
+from ctypes import POINTER, c_char_p, c_int32, c_ubyte, c_uint32, c_void_p
 from ssl import enum_certificates  # type: ignore[attr-defined]
+
+from ._embed import root_der_certificates as _ccadb_root_certificates
 
 # ROOT: Highest level of trust. Trust anchors. Self-Signed.
 # MY: User installed/custom trust anchors. Self-Signed.
@@ -40,7 +46,243 @@ def root_der_certificates() -> list[bytes]:
         except PermissionError:  # Defensive: we can't cover that scenario in CI.
             continue
 
+    # Windows lazily materializes trusted roots, so the enumerated stores above
+    # are only a subset of what the OS actually trusts. Enrich the result with
+    # embedded CCADB roots, but ONLY those the Windows trust engine itself
+    # vouches for (via the AuthRoot CTL). CCADB is merely a candidate list;
+    # Windows remains the sole authority, so we never add a certificate the OS
+    # does not recognize.
+    for cert_bytes in _os_trusted_subset(_ccadb_root_certificates()):
+        if cert_bytes not in seen:
+            seen.add(cert_bytes)
+            certificates.append(cert_bytes)
+
     return certificates
+
+
+# The local "ROOT" store only holds roots that have actually been materialized:
+# Windows downloads trusted roots lazily, on demand, so early on the enumerable
+# store is a small subset of what the OS really trusts. To see the complete
+# trusted set we read the AuthRoot CTL (Certificate Trust List), which lists
+# every program root by SHA-1 thumbprint -- materialized or not -- and keep the
+# embedded CCADB candidates whose thumbprint (and TLS server-auth EKU) it lists.
+_DWORD = c_uint32
+_BOOL = c_int32
+
+# X509_ASN_ENCODING | PKCS_7_ASN_ENCODING
+_ENCODING_TYPES = 0x00000001 | 0x00010000
+
+# The trusted-root CTL is cached as the "EncodedCtl" binary value under
+# AuthRoot\AutoUpdate, with SHA-1 SubjectIdentifiers. (A distrust CTL lives
+# alongside as DisallowedCertEncodedCtl, but it identifies certs by *signature
+# hash* -- CERT_SIGNATURE_HASH_PROP_ID -- not by thumbprint, so a thumbprint
+# match cannot subtract it; for roots that distrust is moot anyway, since a
+# distrusted root is dropped from the trusted CTL we gate on.)
+_AUTHROOT_AUTOUPDATE_KEY = r"SOFTWARE\Microsoft\SystemCertificates\AuthRoot\AutoUpdate"
+_AUTHROOT_CTL_VALUE = "EncodedCtl"
+
+# A CTL entry stores per-root properties as attributes. The EKU property is keyed
+# by szOID_CERT_PROP_ID_PREFIX + CERT_ENHKEY_USAGE_PROP_ID (9). Its value is the
+# DER-encoded EKU OID sequence; absence of the property means "all purposes".
+_EKU_PROP_OID = b"1.3.6.1.4.1.311.10.11.9"
+# DER encodings of the OIDs we accept for TLS server authentication.
+_SERVER_AUTH_OID_DER = bytes.fromhex("06082B06010505070301")  # 1.3.6.1.5.5.7.3.1
+_ANY_EKU_OID_DER = bytes.fromhex("0604551D2500")  # 2.5.29.37.0 (anyExtendedKeyUsage)
+
+
+class _CRYPT_BLOB(ctypes.Structure):
+    # CRYPTOAPI_BLOB; CRYPT_DATA_BLOB / CRYPT_INTEGER_BLOB / CRYPT_OBJID_BLOB share this shape.
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crypt_integer_blob
+    _fields_ = (
+        ("cbData", _DWORD),
+        ("pbData", POINTER(c_ubyte)),
+    )
+
+
+class _CTL_USAGE(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-ctl_usage
+    _fields_ = (
+        ("cUsageIdentifier", _DWORD),
+        ("rgpszUsageIdentifier", POINTER(c_char_p)),
+    )
+
+
+class _FILETIME(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/minwinbase/ns-minwinbase-filetime
+    _fields_ = (
+        ("dwLowDateTime", _DWORD),
+        ("dwHighDateTime", _DWORD),
+    )
+
+
+class _CRYPT_ALGORITHM_IDENTIFIER(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crypt_algorithm_identifier
+    _fields_ = (
+        ("pszObjId", c_char_p),
+        ("Parameters", _CRYPT_BLOB),
+    )
+
+
+class _CRYPT_ATTRIBUTE(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-crypt_attribute
+    _fields_ = (
+        ("pszObjId", c_char_p),
+        ("cValue", _DWORD),
+        ("rgValue", POINTER(_CRYPT_BLOB)),
+    )
+
+
+class _CTL_ENTRY(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-ctl_entry
+    _fields_ = (
+        ("SubjectIdentifier", _CRYPT_BLOB),  # SHA-1 thumbprint of the trusted root
+        ("cAttribute", _DWORD),
+        ("rgAttribute", POINTER(_CRYPT_ATTRIBUTE)),
+    )
+
+
+class _CTL_INFO(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-ctl_info
+    _fields_ = (
+        ("dwVersion", _DWORD),
+        ("SubjectUsage", _CTL_USAGE),
+        ("ListIdentifier", _CRYPT_BLOB),
+        ("SequenceNumber", _CRYPT_BLOB),
+        ("ThisUpdate", _FILETIME),
+        ("NextUpdate", _FILETIME),
+        ("SubjectAlgorithm", _CRYPT_ALGORITHM_IDENTIFIER),
+        ("cCTLEntry", _DWORD),
+        ("rgCTLEntry", POINTER(_CTL_ENTRY)),
+        ("cExtension", _DWORD),
+        ("rgExtension", c_void_p),
+    )
+
+
+class _CTL_CONTEXT(ctypes.Structure):
+    # https://learn.microsoft.com/en-us/windows/win32/api/wincrypt/ns-wincrypt-ctl_context
+    _fields_ = (
+        ("dwMsgAndCertEncodingType", _DWORD),
+        ("pbCtlEncoded", POINTER(c_ubyte)),
+        ("cbCtlEncoded", _DWORD),
+        ("pCtlInfo", POINTER(_CTL_INFO)),
+        ("hCertStore", c_void_p),
+        ("hCryptMsg", c_void_p),
+        ("pbCtlContent", POINTER(c_ubyte)),
+        ("cbCtlContent", _DWORD),
+    )
+
+
+# Load crypt32 and bind the CTL function prototypes at import time. Guarded by
+# the platform check so non-Windows never touches WinDLL;
+_crypt32 = None
+_CertCreateCTLContext = None
+_CertFreeCTLContext = None
+if sys.platform == "win32":
+    try:
+        _crypt32 = ctypes.WinDLL("crypt32", use_last_error=True)
+    except OSError:  # Defensive: crypt32 failed to load.
+        _crypt32 = None
+    else:
+        _CertCreateCTLContext = _crypt32.CertCreateCTLContext
+        _CertCreateCTLContext.argtypes = [_DWORD, c_char_p, _DWORD]
+        _CertCreateCTLContext.restype = POINTER(_CTL_CONTEXT)
+
+        _CertFreeCTLContext = _crypt32.CertFreeCTLContext
+        _CertFreeCTLContext.argtypes = [POINTER(_CTL_CONTEXT)]
+        _CertFreeCTLContext.restype = _BOOL
+
+
+def _sha1(data: bytes) -> bytes:
+    """SHA-1 digest used purely as an identity/join key against the CTL."""
+    try:
+        return hashlib.sha1(data, usedforsecurity=False).digest()
+    except TypeError:  # Defensive: missing usedforsecurity
+        return hashlib.sha1(data).digest()
+
+
+def _read_authroot_encoded_ctl() -> bytes | None:
+    """Read the trusted-root CTL blob from the registry. Returns the raw
+    (DER / PKCS#7-signed) bytes if available.
+    """
+    if sys.platform != "win32":  # Defensive: winreg is Windows-only.
+        return None
+    import winreg
+
+    try:
+        key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, _AUTHROOT_AUTOUPDATE_KEY)
+    except OSError:
+        return None
+
+    try:
+        try:
+            data, _ = winreg.QueryValueEx(key, _AUTHROOT_CTL_VALUE)
+        except OSError:
+            return None
+        if isinstance(data, (bytes, bytearray)) and data[:1] == b"\x30":  # ASN.1 SEQUENCE tag (0x30)
+            return bytes(data)
+        return None
+    finally:
+        winreg.CloseKey(key)
+
+
+def _entry_allows_server_auth(entry: _CTL_ENTRY) -> bool:
+    """Return True if a CTL entry is trusted for TLS server authentication."""
+    count = entry.cAttribute
+    attrs = entry.rgAttribute
+    if not count or not attrs:
+        return True  # no restriction -> all purposes
+
+    for j in range(count):
+        attr = attrs[j]
+        if attr.pszObjId != _EKU_PROP_OID:
+            continue
+        # Found the EKU property: include only if it lists serverAuth / anyEKU.
+        for k in range(attr.cValue):
+            blob = attr.rgValue[k]
+            if blob.cbData and blob.pbData:
+                raw = ctypes.string_at(blob.pbData, blob.cbData)
+                if _SERVER_AUTH_OID_DER in raw or _ANY_EKU_OID_DER in raw:
+                    return True
+        return False
+
+    return True  # no EKU property -> all purposes
+
+
+def _authroot_ctl_thumbprints() -> set[bytes]:
+    """SHA-1 thumbprints of the roots the AuthRoot CTL trusts for TLS server authentication."""
+    encoded = _read_authroot_encoded_ctl()
+    if _CertCreateCTLContext is None or _CertFreeCTLContext is None or not encoded:
+        return set()
+
+    ctl = _CertCreateCTLContext(_ENCODING_TYPES, encoded, len(encoded))
+    if not ctl:
+        return set()
+
+    thumbprints: set[bytes] = set()
+    try:
+        info = ctl.contents.pCtlInfo.contents
+        entries = info.rgCTLEntry
+        for i in range(info.cCTLEntry):
+            entry = entries[i]
+            if not _entry_allows_server_auth(entry):
+                continue
+            blob = entry.SubjectIdentifier
+            if blob.cbData and blob.pbData:
+                thumbprints.add(ctypes.string_at(blob.pbData, blob.cbData))
+    finally:
+        _CertFreeCTLContext(ctl)
+
+    return thumbprints
+
+
+def _os_trusted_subset(candidates: list[bytes]) -> list[bytes]:
+    """Guarantees every added certificate is one the OS's trust list recognizes!"""
+    if not candidates:
+        return []
+    trusted = _authroot_ctl_thumbprints()
+    if not trusted:
+        return []
+    return [der for der in candidates if _sha1(der) in trusted]
 
 
 __all__ = ("root_der_certificates",)

--- a/src/wassima/_os/_windows.py
+++ b/src/wassima/_os/_windows.py
@@ -210,17 +210,17 @@ def _read_authroot_encoded_ctl() -> bytes | None:
 
     try:
         key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, _AUTHROOT_AUTOUPDATE_KEY)
-    except OSError:
+    except OSError:  # Defensive: registry key unavailable
         return None
 
     try:
         try:
             data, _ = winreg.QueryValueEx(key, _AUTHROOT_CTL_VALUE)
-        except OSError:
+        except OSError:  # Defensive: CTL value unavailable
             return None
         if isinstance(data, (bytes, bytearray)) and data[:1] == b"\x30":  # ASN.1 SEQUENCE tag (0x30)
             return bytes(data)
-        return None
+        return None  # Defensive: value is not a CTL blob
     finally:
         winreg.CloseKey(key)
 
@@ -230,7 +230,7 @@ def _entry_allows_server_auth(entry: _CTL_ENTRY) -> bool:
     count = entry.cAttribute
     attrs = entry.rgAttribute
     if not count or not attrs:
-        return True  # no restriction -> all purposes
+        return True  # Defensive: entry without attributes -> all purposes
 
     for j in range(count):
         attr = attrs[j]
@@ -252,11 +252,11 @@ def _authroot_ctl_thumbprints() -> set[bytes]:
     """SHA-1 thumbprints of the roots the AuthRoot CTL trusts for TLS server authentication."""
     encoded = _read_authroot_encoded_ctl()
     if _CertCreateCTLContext is None or _CertFreeCTLContext is None or not encoded:
-        return set()
+        return set()  # Defensive: crypt32 unavailable or no CTL blob
 
     ctl = _CertCreateCTLContext(_ENCODING_TYPES, encoded, len(encoded))
     if not ctl:
-        return set()
+        return set()  # Defensive: CTL failed to decode
 
     thumbprints: set[bytes] = set()
     try:
@@ -281,7 +281,7 @@ def _os_trusted_subset(candidates: list[bytes]) -> list[bytes]:
         return []
     trusted = _authroot_ctl_thumbprints()
     if not trusted:
-        return []
+        return []  # Defensive: empty OS trust list
     return [der for der in candidates if _sha1(der) in trusted]
 
 

--- a/src/wassima/_version.py
+++ b/src/wassima/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "2.1.0"
+__version__ = "2.1.1"
 VERSION = __version__.split(".")

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import ssl
+import sys
 import time
 from typing import Iterator
 
@@ -272,9 +274,66 @@ def test_windows_backend_dedups_across_stores(monkeypatch) -> None:  # type: ign
     # works whether the module was just imported or was already cached at
     # process startup (which is the case on Windows).
     monkeypatch.setattr(win_mod, "enum_certificates", fake_enum_certificates)
+    # Isolate store dedup from the CCADB enrichment step.
+    monkeypatch.setattr(win_mod, "_ccadb_root_certificates", list)
 
     certs = win_mod.root_der_certificates()
     assert certs == [duplicate]
+
+
+def test_windows_root_certs_enriched_with_os_vetted_ccadb(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    import hashlib
+    import ssl as _ssl
+
+    if not hasattr(_ssl, "enum_certificates"):
+        monkeypatch.setattr(_ssl, "enum_certificates", lambda store: iter([]), raising=False)
+
+    from wassima._os import _windows as win_mod
+
+    materialized = b"\xaamaterialized-root"
+
+    def fake_enum(store: str):  # type: ignore[no-untyped-def]
+        yield (materialized, "x509_asn", True)
+
+    monkeypatch.setattr(win_mod, "enum_certificates", fake_enum)
+
+    ccadb_extra = b"\xbbctl-listed-not-materialized"  # in CTL, not in store -> add
+    ccadb_unknown = b"\xccnot-in-ctl"  # absent from CTL -> skip
+    monkeypatch.setattr(
+        win_mod,
+        "_ccadb_root_certificates",
+        lambda: [materialized, ccadb_extra, ccadb_unknown],
+    )
+
+    # The CTL lists the materialized root and the extra (by SHA-1), not the unknown.
+    ctl = {hashlib.sha1(materialized).digest(), hashlib.sha1(ccadb_extra).digest()}
+    monkeypatch.setattr(win_mod, "_authroot_ctl_thumbprints", lambda: ctl)
+
+    certs = win_mod.root_der_certificates()
+
+    # Materialized root (from store) + CTL-listed extra CCADB root; the unknown
+    # candidate is excluded, and the materialized one is not duplicated even
+    # though it is also a CCADB candidate listed in the CTL.
+    assert certs == [materialized, ccadb_extra]
+
+
+def test_windows_os_trusted_subset_matches_by_sha1(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    """The AuthRoot CTL keys roots by SHA-1 thumbprint, so the subset filter must
+    match candidates by their SHA-1 digest."""
+    import hashlib
+    import ssl as _ssl
+
+    if not hasattr(_ssl, "enum_certificates"):
+        monkeypatch.setattr(_ssl, "enum_certificates", lambda store: iter([]), raising=False)
+
+    from wassima._os import _windows as win_mod
+
+    listed = b"\x01ctl-listed"
+    not_listed = b"\x02not-in-ctl"
+
+    monkeypatch.setattr(win_mod, "_authroot_ctl_thumbprints", lambda: {hashlib.sha1(listed).digest()})
+
+    assert win_mod._os_trusted_subset([listed, not_listed]) == [listed]
 
 
 def test_no_deadlock_between_register_ca_and_root_certs(monkeypatch) -> None:  # type: ignore[no-untyped-def]
@@ -322,3 +381,34 @@ def test_no_deadlock_between_register_ca_and_root_certs(monkeypatch) -> None:  #
     threading.Thread(target=watchdog, daemon=True).start()
 
     assert done.wait(timeout=15), "deadlock detected between register_ca and root_der_certificates"
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="MacOS only")
+def test_macos_fork_guard_falls_back_to_ccadb() -> None:
+    """On macOS, calling into Security.framework/CoreFoundation from a process
+    that forked without exec() is not fork-safe and crashes.
+    """
+    # Ensure the child recomputes from scratch (i.e. actually hits the backend
+    # guard) instead of reading a value warmed in the parent.
+    root_der_certificates.cache_clear()
+
+    embed = fallback_der_certificates()
+    assert embed, "embedded CCADB bundle should not be empty"
+
+    pid = os.fork()
+    if pid == 0:  # child: must _exit and never raise back into pytest
+        try:
+            certs = root_der_certificates()
+            # In a forked child the native store is skipped, so the result is
+            # exactly the embedded CCADB bundle.
+            ok = certs == embed
+        except BaseException:
+            os._exit(2)
+        os._exit(0 if ok else 1)
+
+    _, status = os.waitpid(pid, 0)
+
+    if os.WIFSIGNALED(status):
+        pytest.fail(f"child crashed with signal {os.WTERMSIG(status)} (fork guard did not prevent the native call)")
+    assert os.WIFEXITED(status)
+    assert os.WEXITSTATUS(status) == 0, "child did not return the embedded CCADB bundle after fork"

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -401,20 +401,10 @@ def test_macos_fork_guard_falls_back_to_ccadb() -> None:
             certs = root_der_certificates()
             # In a forked child the native store is skipped, so the result is
             # exactly the embedded CCADB bundle.
-            code = 0 if certs == embed else 1
+            ok = certs == embed
         except BaseException:
-            code = 2
-        # force coverage to persist current coverage.
-        # fork exit bypass atexit.
-        try:
-            import coverage  # type: ignore[import-not-found]
-
-            cov = coverage.Coverage.current()
-            if cov is not None:
-                cov.save()
-        except Exception:
-            pass
-        os._exit(code)
+            os._exit(2)
+        os._exit(0 if ok else 1)
 
     _, status = os.waitpid(pid, 0)
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -401,10 +401,20 @@ def test_macos_fork_guard_falls_back_to_ccadb() -> None:
             certs = root_der_certificates()
             # In a forked child the native store is skipped, so the result is
             # exactly the embedded CCADB bundle.
-            ok = certs == embed
+            code = 0 if certs == embed else 1
         except BaseException:
-            os._exit(2)
-        os._exit(0 if ok else 1)
+            code = 2
+        # force coverage to persist current coverage.
+        # fork exit bypass atexit.
+        try:
+            import coverage  # type: ignore[import-not-found]
+
+            cov = coverage.Coverage.current()
+            if cov is not None:
+                cov.save()
+        except Exception:
+            pass
+        os._exit(code)
 
     _, status = os.waitpid(pid, 0)
 


### PR DESCRIPTION
## 2.1.1 (2026-06-07)

### Fixed
- Guarded MacOS truststore access in process forks. Apple document as unsafe accessing some CoreFoundation/Security in forks.
  Previously could lead to a crash (SIGABRT or SIGSEGV). Now automatically falling back to CCADB bundle if in such condition.
- Windows only materializes trusted roots on demand, so the enumerated OS store could be incomplete and
  cause `unable to get local issuer certificate` failures. Now extended with the embedded CCADB roots that the Windows AuthRoot
  CTL trusts for server authentication, even when not yet downloaded locally. (#52)
