### PR TITLE
Release 2.1.2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-22.04, ubuntu-24.04, macos-14, macos-15, macos-26, windows-latest ]
-        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11', '3.14']
+        python_version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13', 'pypy-3.7', 'pypy-3.8', 'pypy-3.9', 'pypy-3.10', 'pypy-3.11', '3.14', '3.15']
         exclude:
           - os: macos-14
             python_version: '3.7'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to wassima will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 2.1.2 (2026-07-07)
+
+### Changed
+- CCADB embedded bundle is updated to latest version. (#55)
+
+### Misc
+- Explicit support for Python 3.15
+
 ## 2.1.1 (2026-06-07)
 
 ### Fixed

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import os
 import nox
 
 
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "3.15", "pypy"])
 def test(session: nox.Session) -> None:
     # Install deps and the package itself.
     session.install("-r", "requirements-dev.txt")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3.15",
     "Programming Language :: Python :: 3 :: Only",
     "Intended Audience :: Developers",
     "Operating System :: OS Independent",

--- a/src/wassima/_version.py
+++ b/src/wassima/_version.py
@@ -1,4 +1,4 @@
 from __future__ import annotations
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 VERSION = __version__.split(".")


### PR DESCRIPTION
## 2.1.2 (2026-07-07)

### Changed
- CCADB embedded bundle is updated to latest version. (#55)

### Misc
- Explicit support for Python 3.15
